### PR TITLE
Fix decoding failing for badly escaped characters

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -380,7 +380,7 @@ function readUint8String(buffer, length, offset, raw) {
         if(raw) {
             return str;
         }
-        return decodeURIComponent(escape(str));
+        return decodeURIComponent(encodeURIComponent(str));
     }
 }
 


### PR DESCRIPTION
The str `çÑÇ` encodes into `%E7%D1%C7%0A`, which throws `URIError: URI malformed` when using `decodeURIComponent` .

I am not sure why there is an `escape` there in the first place, but using `encodeURIComponent` (like suggested [here on the deprecated page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape)) seems to work for all files for me.