### PR TITLE
encoding type 0 is ISO-8859, not UTF8

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -184,7 +184,15 @@ function parseFrame(buffer, minor, size) {
         encoding = buffer[10];
         
         // TODO: Implement UTF-8, UTF-16 and UTF-16 with BOM properly?
-        if(encoding === 0 || encoding === 3) {
+        if(encoding === 0) {
+          result.value = (new Uint8Array(buffer.slice(11)))
+            .reduce(
+              function (str, byte) {
+                return str + String.fromCharCode(byte);
+              },
+              ''
+            );
+        } else if (encoding === 3) {
             result.value = readUTF8String(buffer.slice(11)); 
         } else if(encoding === 1 || encoding === 2) {
             result.value = readUTF16String(buffer.slice(11));


### PR DESCRIPTION
Decoding ISO-8859 characters as UTF8 works fine for characters up to 0x80 but fails on the bottom part of of the table:  https://en.wikipedia.org/wiki/ISO/IEC_8859-1#Codepage_layout because it assumes that the full ISO-8859 character is just the fist part of a two character UTF8 and tries to merge its bits with those of the next character.  ISO-8859 characters just need to be converted via `fromCharCode`