### PR TITLE
add typescript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,10 @@ module.exports = {
 }
 ```
 
-## Typings
-
-A typing definition file for use with id3-parser when programming in Typescript is available [here](https://github.com/dvdcxn/typed-id3-parser). Alternatively, it may be installed using [Typings](https://github.com/typings/typings). To do so, execute the following command within a folder/project with a `typings.json` file:
-
-```bash
-typings install id3-parser --save
+## Typescript
+Typescript typings are shipped with the package. To use id3-parser in typescript, do:
+```typescript
+import * as id3Parser from 'id3-parser';
 ```
 
 ## License

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,106 @@
+declare module 'id3-parser' {
+    export function parse(file: File | Uint8Array | Buffer): PromiseLike<Partial<Tags>>;
+
+    export interface Tags {
+        /*
+        * Textual frames
+        */
+        'album': string,
+        'bpm': string,
+        'composer': string,
+        'genre': string,
+        'copyright': string,
+        'encoding-time': string,
+        'playlist-delay': string,
+        'original-release-time': string,
+        'recording-time': string,
+        'release-time': string,
+        'tagging-time': string,
+        'encoder': string,
+        'writer': string,
+        'file-type': string,
+        'involved-people': string,
+        'content-group': string,
+        'title': string,
+        'subtitle': string,
+        'initial-key': string,
+        'language': string,
+        'length': string,
+        'credits': string,
+        'media-type': string,
+        'mood': string,
+        'original-album': string,
+        'original-filename': string,
+        'original-writer': string,
+        'original-artist': string,
+        'owner': string,
+        'artist': string,
+        'band': string,
+        'conductor': string,
+        'remixer': string,
+        'set-part': string,
+        'produced-notice': string,
+        'publisher': string,
+        'track': string,
+        'radio-name': string,
+        'radio-owner': string,
+        'album-sort': string,
+        'performer-sort': string,
+        'title-sort': string,
+        'isrc': string,
+        'encoder-settings': string,
+        'set-subtitle': string,
+        'user-defined-text-information': string,
+        'year': string,
+
+        /*
+         * URL frames
+         */
+        'url-commercial': string,
+        'url-legal': string,
+        'url-file': string,
+        'url-artist': string,
+        'url-source': string,
+        'url-radio': string,
+        'url-payment': string,
+        'url-publisher': string,
+        'url-copyright': string,
+
+        /*
+         * Comment frame
+         */
+        'comments': string,
+        'lyrics': string,
+
+        version: VersionInfo
+        image: Image,
+    }
+
+    export interface VersionInfo {
+        v1: v1VersionInfo,
+        v2: v2VersionInfo
+    }
+
+    export interface v1VersionInfo {
+        major: number,
+        minor: number
+    }
+
+    export interface v2VersionInfo extends v1VersionInfo {
+        revision: number,
+        flags: Flags
+    }
+
+    export interface Flags {
+        unsync: number,
+        xheader: number,
+        experimental: number
+    }
+
+    export interface Image {
+        type: string,
+        mime: string,
+        imageType: string,
+        descriptions: string
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "A pure JavaScript id3 tag parser.",
   "main": "lib/parser.js",
+  "typings": "index.d.ts",
   "files": [
     "dest",
     "lib"


### PR DESCRIPTION
[Typings](https://github.com/typings/typings) project is deprecated (the advised way now is using `@types` or shipping type definitions with npm package), and current typings from https://github.com/dvdcxn/typed-id3-parser are incomplete. This PR adds complete type definitions shipped with the package.